### PR TITLE
[build] add missing dependences for parallel builds

### DIFF
--- a/decoder/build/linux/makefile
+++ b/decoder/build/linux/makefile
@@ -136,7 +136,7 @@ $(LIB_TARGET_DIR)/lib$(LIB_BASE_NAME).so:
 #
 $(LIB_CAPI_NAME)_lib: $(LIB_TARGET_DIR)/lib$(LIB_CAPI_NAME).a
 
-$(LIB_TARGET_DIR)/lib$(LIB_CAPI_NAME).a:
+$(LIB_TARGET_DIR)/lib$(LIB_CAPI_NAME).a: $(LIB_BASE_NAME)_lib
 	mkdir -p $(LIB_TARGET_DIR)
 	cd $(OCSD_ROOT)/build/linux/rctdl_c_api_lib && make
 
@@ -145,7 +145,7 @@ $(LIB_TARGET_DIR)/lib$(LIB_CAPI_NAME).a:
 #
 $(LIB_CAPI_NAME)_so: $(LIB_TARGET_DIR)/lib$(LIB_CAPI_NAME).so
 
-$(LIB_TARGET_DIR)/lib$(LIB_CAPI_NAME).so: $(LIB_BASE_NAME)_lib
+$(LIB_TARGET_DIR)/lib$(LIB_CAPI_NAME).so: $(LIB_BASE_NAME)_so
 	mkdir -p $(LIB_TARGET_DIR)
 	cd $(OCSD_ROOT)/build/linux/rctdl_c_api_lib && make
 


### PR DESCRIPTION
When compiling with "make -j8" the build used to fail with two errors:

g++ -Wl,-z,defs  -shared -o /root/etm/decoder/decoder/lib/linux/dbg/libcstraced_c_api.so -Wl,-soname,libcstraced_c_api.so ./linux/dbg/ocsd_c_api.o ./linux/dbg/ocsd_c_api_deprc_fn.o -L/root/etm/decoder/decoder/lib/linux/dbg -lcstraced
/usr/bin/ld: cannot find -lcstraced

[...]

g++ -Wl,-z,defs "-m64" -shared -o decoder/lib/linux64/dbg/libcstraced_c_api.so -Wl,-soname,libcstraced_c_api.so ./linux64/dbg/ocsd_c_api.o ./linux64/dbg/ocsd_c_api_deprc_fn.o -Ldecoder/lib/linux64/dbg -lcstraced
decoder/lib/linux64/dbg/libcstraced.so: file not recognized: File truncated

This patch fixes the missing dependences for both static and shared libcstraced_c_api.