### PR TITLE
A set of patches to fix build dependencies problems

### DIFF
--- a/decoder/build/linux/makefile
+++ b/decoder/build/linux/makefile
@@ -139,7 +139,7 @@ $(LIB_TARGET_DIR)/lib$(LIB_BASE_NAME).a: $(LIB_BASE_NAME)_all
 # single command builds both .a and .so targets in sub-makefile
 $(LIB_BASE_NAME)_all:
 	mkdir -p $(LIB_TARGET_DIR)
-	cd $(OCSD_ROOT)/build/linux/ref_trace_decode_lib && make
+	cd $(OCSD_ROOT)/build/linux/ref_trace_decode_lib && $(MAKE)
 
 ################################
 # build OpenCSD trace decode C API library 
@@ -152,17 +152,17 @@ $(LIB_TARGET_DIR)/lib$(LIB_CAPI_NAME).a:  $(LIB_CAPI_NAME)_all
 # single command builds both .a and .so targets in sub-makefile
 $(LIB_CAPI_NAME)_all:  $(LIB_BASE_NAME)_lib
 	mkdir -p $(LIB_TARGET_DIR)
-	cd $(OCSD_ROOT)/build/linux/rctdl_c_api_lib && make
+	cd $(OCSD_ROOT)/build/linux/rctdl_c_api_lib && $(MAKE)
 
 #################################
 # build tests
 
 .PHONY: tests
 tests: libs
-	cd $(OCSD_ROOT)/tests/build/linux/echo_test_dcd_lib && make
-	cd $(OCSD_ROOT)/tests/build/linux/snapshot_parser_lib && make
-	cd $(OCSD_ROOT)/tests/build/linux/trc_pkt_lister && make
-	cd $(OCSD_ROOT)/tests/build/linux/c_api_pkt_print_test && make
+	cd $(OCSD_ROOT)/tests/build/linux/echo_test_dcd_lib && $(MAKE)
+	cd $(OCSD_ROOT)/tests/build/linux/snapshot_parser_lib && $(MAKE)
+	cd $(OCSD_ROOT)/tests/build/linux/trc_pkt_lister && $(MAKE)
+	cd $(OCSD_ROOT)/tests/build/linux/c_api_pkt_print_test && $(MAKE)
 
 #
 # build docs
@@ -179,14 +179,14 @@ clean: clean_libs clean_tests clean_docs
 .PHONY: clean_libs clean_tests clean_docs clean_install
 
 clean_libs:
-	cd $(OCSD_ROOT)/build/linux/ref_trace_decode_lib && make clean
-	cd $(OCSD_ROOT)/build/linux/rctdl_c_api_lib && make clean
+	cd $(OCSD_ROOT)/build/linux/ref_trace_decode_lib && $(MAKE) clean
+	cd $(OCSD_ROOT)/build/linux/rctdl_c_api_lib && $(MAKE) clean
 
 clean_tests:
-	cd $(OCSD_ROOT)/tests/build/linux/echo_test_dcd_lib && make clean
-	cd $(OCSD_ROOT)/tests/build/linux/snapshot_parser_lib && make clean
-	cd $(OCSD_ROOT)/tests/build/linux/trc_pkt_lister && make clean
-	cd $(OCSD_ROOT)/tests/build/linux/c_api_pkt_print_test && make clean
+	cd $(OCSD_ROOT)/tests/build/linux/echo_test_dcd_lib && $(MAKE) clean
+	cd $(OCSD_ROOT)/tests/build/linux/snapshot_parser_lib && $(MAKE) clean
+	cd $(OCSD_ROOT)/tests/build/linux/trc_pkt_lister && $(MAKE) clean
+	cd $(OCSD_ROOT)/tests/build/linux/c_api_pkt_print_test && $(MAKE) clean
 	-rmdir $(OCSD_TESTS)/lib
 
 clean_docs:

--- a/decoder/tests/build/linux/c_api_pkt_print_test/makefile
+++ b/decoder/tests/build/linux/c_api_pkt_print_test/makefile
@@ -53,10 +53,10 @@ LIBS		=	-L$(LIB_TARGET_DIR) -l$(LIB_BASE_NAME) -l$(LIB_CAPI_NAME) \
 
 all:  build_dir test_app copy_libs
 
-test_app: 	$(OBJECTS) $(BIN_TEST_TARGET_DIR)/$(PROG)
+test_app: 	$(BIN_TEST_TARGET_DIR)/$(PROG)
 
 
- $(BIN_TEST_TARGET_DIR)/$(PROG):
+ $(BIN_TEST_TARGET_DIR)/$(PROG): $(OBJECTS)
 			mkdir -p  $(BIN_TEST_TARGET_DIR)
 			$(LINKER) $(LDFLAGS) $(OBJECTS) -Wl,--start-group $(LIBS) -Wl,--end-group -o $(BIN_TEST_TARGET_DIR)/$(PROG)
 			cp $(LIB_TARGET_DIR)/*.so .

--- a/decoder/tests/build/linux/c_api_pkt_print_test/makefile
+++ b/decoder/tests/build/linux/c_api_pkt_print_test/makefile
@@ -51,7 +51,7 @@ OBJECTS		=	$(BUILD_DIR)/c_api_pkt_print_test.o
 LIBS		=	-L$(LIB_TARGET_DIR) -l$(LIB_BASE_NAME) -l$(LIB_CAPI_NAME) \
 				-L$(LIB_TEST_TARGET_DIR) -l_echo_test_dcd
 
-all:  build_dir test_app copy_libs
+all:  build_dir copy_libs
 
 test_app: 	$(BIN_TEST_TARGET_DIR)/$(PROG)
 
@@ -65,8 +65,7 @@ build_dir:
 	mkdir -p $(BUILD_DIR)
 
 .PHONY: copy_libs
-
-copy_libs:
+copy_libs: $(BIN_TEST_TARGET_DIR)/$(PROG)
 	cp $(LIB_TARGET_DIR)/*.so $(BIN_TEST_TARGET_DIR)/.
 
 

--- a/decoder/tests/build/linux/echo_test_dcd_lib/makefile
+++ b/decoder/tests/build/linux/echo_test_dcd_lib/makefile
@@ -57,12 +57,6 @@ $(LIB_TEST_TARGET_DIR)/$(LIB_NAME).a: $(OBJECTS)
 build_dir:
 	mkdir -p $(BUILD_DIR)
 
-.PHONY: copy_libs
-
-copy_libs:
-	cp $(LIB_TARGET_DIR)/*.so $(BIN_TEST_TARGET_DIR)/.
-
-
 #### build rules
 ## object dependencies
 DEPS := $(OBJECTS:%.o=%.d)

--- a/decoder/tests/build/linux/echo_test_dcd_lib/makefile
+++ b/decoder/tests/build/linux/echo_test_dcd_lib/makefile
@@ -48,9 +48,9 @@ CC_INCLUDES	=	\
 OBJECTS		=	$(BUILD_DIR)/ext_dcd_echo_test.o \
 				$(BUILD_DIR)/ext_dcd_echo_test_fact.o
 
-all:  build_dir  $(OBJECTS) $(LIB_TEST_TARGET_DIR)/$(LIB_NAME).a
+all:  build_dir $(LIB_TEST_TARGET_DIR)/$(LIB_NAME).a
 
-$(LIB_TEST_TARGET_DIR)/$(LIB_NAME).a:
+$(LIB_TEST_TARGET_DIR)/$(LIB_NAME).a: $(OBJECTS)
 	mkdir -p $(LIB_TEST_TARGET_DIR)
 	$(LIB) $(ARFLAGS) $(LIB_TEST_TARGET_DIR)/$(LIB_NAME).a $(OBJECTS)
 

--- a/decoder/tests/build/linux/snapshot_parser_lib/makefile
+++ b/decoder/tests/build/linux/snapshot_parser_lib/makefile
@@ -63,9 +63,9 @@ OBJECTS=$(BUILD_DIR)/device_info.o \
 		$(BUILD_DIR)/snapshot_reader.o \
 		$(BUILD_DIR)/ss_to_dcdtree.o
 
-all: build_dir $(OBJECTS) $(LIB_TEST_TARGET_DIR)/$(LIB_NAME).a
+all: build_dir $(LIB_TEST_TARGET_DIR)/$(LIB_NAME).a
 
-$(LIB_TEST_TARGET_DIR)/$(LIB_NAME).a:
+$(LIB_TEST_TARGET_DIR)/$(LIB_NAME).a: $(OBJECTS)
 	mkdir -p $(LIB_TEST_TARGET_DIR)
 	$(LIB) $(ARFLAGS) $(LIB_TEST_TARGET_DIR)/$(LIB_NAME).a $(OBJECTS)
 

--- a/decoder/tests/build/linux/trc_pkt_lister/makefile
+++ b/decoder/tests/build/linux/trc_pkt_lister/makefile
@@ -53,10 +53,10 @@ LIBS		=	-L$(LIB_TEST_TARGET_DIR) -lsnapshot_parser \
 
 all:  build_dir test_app copy_libs
 
-test_app: 	$(OBJECTS) $(BIN_TEST_TARGET_DIR)/$(PROG)
+test_app: $(BIN_TEST_TARGET_DIR)/$(PROG)
 
 
- $(BIN_TEST_TARGET_DIR)/$(PROG):
+ $(BIN_TEST_TARGET_DIR)/$(PROG): $(OBJECTS)
 			mkdir -p  $(BIN_TEST_TARGET_DIR)
 			$(LINKER) $(LDFLAGS) $(OBJECTS) -Wl,--start-group $(LIBS) -Wl,--end-group -o $(BIN_TEST_TARGET_DIR)/$(PROG)
 

--- a/decoder/tests/build/linux/trc_pkt_lister/makefile
+++ b/decoder/tests/build/linux/trc_pkt_lister/makefile
@@ -51,7 +51,7 @@ OBJECTS		=	$(BUILD_DIR)/trc_pkt_lister.o
 LIBS		=	-L$(LIB_TEST_TARGET_DIR) -lsnapshot_parser \
 				-L$(LIB_TARGET_DIR) -l$(LIB_BASE_NAME)
 
-all:  build_dir test_app copy_libs
+all:  build_dir copy_libs
 
 test_app: $(BIN_TEST_TARGET_DIR)/$(PROG)
 
@@ -64,8 +64,7 @@ build_dir:
 	mkdir -p $(BUILD_DIR)
 
 .PHONY: copy_libs
-
-copy_libs:
+copy_libs: $(BIN_TEST_TARGET_DIR)/$(PROG)
 	cp $(LIB_TARGET_DIR)/*.so* $(BIN_TEST_TARGET_DIR)/.
 
 


### PR DESCRIPTION
Hello all,

I was building OpenCSD with -j32 and i found multiple problems and build failures. This patch set attempts to fix them and as far as I tested OpenCSD now builds correctly.

I think there may be more problems with PHONY targets especially the build_dir targets, which is not PHONY and should be. Also it probably should be a dependency of the OBJECTS target if anybody ever uses a BUILD_DIR which is not in the source itself. Let me know if there is interest in such fixes and I can add it to this pull request.

Best regards
Paulo Neves
