### PR TITLE
opencsd_c_api: ocsd_c_api: spelling fix "verison" -> "version"

### DIFF
--- a/decoder/include/opencsd/c_api/opencsd_c_api.h
+++ b/decoder/include/opencsd/c_api/opencsd_c_api.h
@@ -84,7 +84,7 @@
 /** @name Library Version API
 
 @{*/
-/** Get Library version. Return a 32 bit version in form MMMMnnpp - MMMM = major verison, nn = minor version, pp = patch version */ 
+/** Get Library version. Return a 32 bit version in form MMMMnnpp - MMMM = major version, nn = minor version, pp = patch version */ 
 OCSD_C_API uint32_t ocsd_get_version(void);
 
 /** Get library version string */

--- a/decoder/source/c_api/ocsd_c_api.cpp
+++ b/decoder/source/c_api/ocsd_c_api.cpp
@@ -74,7 +74,7 @@ static std::map<dcd_tree_handle_t, lib_dt_data_list *> s_data_map;
 /* C API functions                                                             */
 /*******************************************************************************/
 
-/** Get Library version. Return a 32 bit version in form MMMMnnpp - MMMM = major verison, nn = minor version, pp = patch version */ 
+/** Get Library version. Return a 32 bit version in form MMMMnnpp - MMMM = major version, nn = minor version, pp = patch version */ 
 OCSD_C_API uint32_t ocsd_get_version(void) 
 { 
     return ocsdVersion::vers_num();


### PR DESCRIPTION
Trivial fix to spelling mistakes in comments.

Signed-off-by: Solomon Tan <solomonbstoner@protonmail.ch>