### PR TITLE
Update run_pkt_decode_tests.bash

### DIFF
--- a/decoder/tests/run_pkt_decode_tests.bash
+++ b/decoder/tests/run_pkt_decode_tests.bash
@@ -38,7 +38,6 @@
 
 OUT_DIR=./results
 SNAPSHOT_DIR=./snapshots
-BIN_DIR=./bin/linux64/rel
 
 # directories for tests using full decode
 declare -a test_dirs_decode=( "juno-ret-stck"
@@ -68,6 +67,6 @@ export LD_LIBRARY_PATH=${BIN_DIR}/.
 for test_dir in "${test_dirs_decode[@]}"
 do
     echo "Testing $test_dir..."
-    ${BIN_DIR}/trc_pkt_lister -ss_dir "${SNAPSHOT_DIR}/$test_dir" -decode -logfilename "${OUT_DIR}/$test_dir.ppl"
+    trc_pkt_lister -ss_dir "${SNAPSHOT_DIR}/$test_dir" -decode -logfilename "${OUT_DIR}/$test_dir.ppl"
     echo "Done : Return $?"
 done


### PR DESCRIPTION
Removed $BIN_DIR since error received:
```bash
Running trc_pkt_lister on snapshot directories.
Testing juno-ret-stck...
./run_pkt_decode_tests.bash: line 71: ./bin/linux64/rel/trc_pkt_lister: No such file or directory
Done : Return 127
Testing a57_single_step...
./run_pkt_decode_tests.bash: line 71: ./bin/linux64/rel/trc_pkt_lister: No such file or directory
Done : Return 127
Testing bugfix-exact-match...
./run_pkt_decode_tests.bash: line 71: ./bin/linux64/rel/trc_pkt_lister: No such file or directory
Done : Return 127
Testing juno-uname-001...
./run_pkt_decode_tests.bash: line 71: ./bin/linux64/rel/trc_pkt_lister: No such file or directory
Done : Return 127
Testing juno-uname-002...
./run_pkt_decode_tests.bash: line 71: ./bin/linux64/rel/trc_pkt_lister: No such file or directory
Done : Return 127
Testing juno_r1_1...
./run_pkt_decode_tests.bash: line 71: ./bin/linux64/rel/trc_pkt_lister: No such file or directory
Done : Return 127
Testing tc2-ptm-rstk-t32...
./run_pkt_decode_tests.bash: line 71: ./bin/linux64/rel/trc_pkt_lister: No such file or directory
Done : Return 127
Testing trace_cov_a15...
./run_pkt_decode_tests.bash: line 71: ./bin/linux64/rel/trc_pkt_lister: No such file or directory
Done : Return 127
Testing stm_only...
./run_pkt_decode_tests.bash: line 71: ./bin/linux64/rel/trc_pkt_lister: No such file or directory
Done : Return 127
Testing stm_only-2...
./run_pkt_decode_tests.bash: line 71: ./bin/linux64/rel/trc_pkt_lister: No such file or directory
Done : Return 127
Testing stm_only-juno...
./run_pkt_decode_tests.bash: line 71: ./bin/linux64/rel/trc_pkt_lister: No such file or directory
Done : Return 127
Testing TC2...
./run_pkt_decode_tests.bash: line 71: ./bin/linux64/rel/trc_pkt_lister: No such file or directory
Done : Return 127
Testing Snowball...
./run_pkt_decode_tests.bash: line 71: ./bin/linux64/rel/trc_pkt_lister: No such file or directory
Done : Return 127
Testing test-file-mem-offsets...
./run_pkt_decode_tests.bash: line 71: ./bin/linux64/rel/trc_pkt_lister: No such file or directory
Done : Return 127
```

trc_pkt_lister is installed to `/usr/bin/` directory after `make install`. 

not exactly sure if this is a good fix or not.