### PR TITLE
Fix index out of bound and uninitialized memory reads

### DIFF
--- a/decoder/include/common/ocsd_dcd_mngr.h
+++ b/decoder/include/common/ocsd_dcd_mngr.h
@@ -80,16 +80,16 @@ public:
 
     
 private:
-    ocsd_trace_protocol_t m_builtInProtocol;    //!< Protocol ID if built in type.
+    const ocsd_trace_protocol_t m_builtInProtocol;    //!< Protocol ID if built in type.
 };
 
 template <class P, class Pt, class Pc>
-DecoderMngrBase<P,Pt,Pc>::DecoderMngrBase(const std::string &decoderTypeName, ocsd_trace_protocol_t builtInProtocol)
+    DecoderMngrBase<P,Pt,Pc>::DecoderMngrBase(const std::string &decoderTypeName, ocsd_trace_protocol_t builtInProtocol) :
+        m_builtInProtocol(builtInProtocol)
 {
     OcsdLibDcdRegister *pDcdReg = OcsdLibDcdRegister::getDecoderRegister();
     if(pDcdReg)
         pDcdReg->registerDecoderTypeByName(decoderTypeName,this);
-    m_builtInProtocol = builtInProtocol;
 }
 
 template <class P, class Pt, class Pc>

--- a/decoder/source/ocsd_dcd_tree.cpp
+++ b/decoder/source/ocsd_dcd_tree.cpp
@@ -511,7 +511,7 @@ DecodeTreeElement *DecodeTree::getNextElement(uint8_t &elemID)
     if(m_decode_elem_iter < 0x80)
     {
         // find a none zero entry or end of range
-        while((m_decode_elements[m_decode_elem_iter] == 0) && (m_decode_elem_iter < 0x80))
+        while((m_decode_elem_iter < 0x80) && (m_decode_elements[m_decode_elem_iter] == 0))
             m_decode_elem_iter++;
 
         // return entry unless end of range

--- a/decoder/source/ocsd_gen_elem_stack.cpp
+++ b/decoder/source/ocsd_gen_elem_stack.cpp
@@ -42,6 +42,7 @@ OcsdGenElemStack::OcsdGenElemStack() :
     m_curr_elem_idx(0),
     m_send_elem_idx(0),
     m_CSID(0),
+    m_sendIf(NULL),
     m_is_init(false)
 {
 

--- a/decoder/source/ptm/trc_pkt_proc_ptm.cpp
+++ b/decoder/source/ptm/trc_pkt_proc_ptm.cpp
@@ -224,6 +224,7 @@ void TrcPktProcPtm::InitProcessorState()
     m_waitASyncSOPkt = false;
     m_bAsyncRawOp = false;
     m_bOPNotSyncPkt = false;
+    m_excepAltISA = 0;
 
     m_curr_packet.ResetState();
     InitPacketState();


### PR DESCRIPTION
These issues were found using LLVM's address and memory sanitizer running the c_api_pkt_print_test with the different decoder types.