### PR TITLE
tests: Include <algorithm> in snapshot_parser_util.h

### DIFF
--- a/decoder/tests/snapshot_parser_lib/include/snapshot_parser_util.h
+++ b/decoder/tests/snapshot_parser_lib/include/snapshot_parser_util.h
@@ -35,6 +35,7 @@
 #ifndef ARM_SNAPSHOT_PARSER_UTIL_H_INCLUDED
 #define ARM_SNAPSHOT_PARSER_UTIL_H_INCLUDED
 
+#include <algorithm>
 #include <string>
 #include <sstream>
 #include <iomanip>


### PR DESCRIPTION
std::lexicographical_compare usage in snapshot_parser_util.h
requires <algorithm>.
This fixes a build breakage when using ToT libc++ which
no longer transitively include <algorithm>.

Signed-off-by: Manoj Gupta <manojgupta@google.com>