### PR TITLE
After the packet "Version" the channel and master were not reset to zero

### DIFF
--- a/decoder/source/stm/trc_pkt_decode_stm.cpp
+++ b/decoder/source/stm/trc_pkt_decode_stm.cpp
@@ -175,6 +175,9 @@ ocsd_datapath_resp_t TrcPktDecodeStm::decodePacket(bool &bPktDone)
         break;
 
     case STM_PKT_VERSION:    /**< Version packet  - not relevant to generic (versionless) o/p */
+        m_swt_packet_info.swt_master_id = m_curr_packet_in->getMaster();
+        m_swt_packet_info.swt_channel_id = m_curr_packet_in->getChannel();
+        break; 
     case STM_PKT_ASYNC:      /**< Alignment synchronisation packet */
     case STM_PKT_INCOMPLETE_EOT:     /**< Incomplete packet flushed at end of trace. */
         // no action required.


### PR DESCRIPTION
This was done by the processor but not the decoder.  This is a bug as if after a Version packet master 0 starts generating packets the master ID and the Channel do not get updated.
This is a really bad bug, took me a while to figure out. 