### PR TITLE
Add #include <cstdlib> for strtol and getenv.

### DIFF
--- a/decoder/source/etmv4/trc_pkt_decode_etmv4i.cpp
+++ b/decoder/source/etmv4/trc_pkt_decode_etmv4i.cpp
@@ -34,6 +34,8 @@
 
 #include "opencsd/etmv4/trc_pkt_decode_etmv4i.h"
 
+#include <cstdlib>
+
 #include "common/trc_gen_elem.h"
 
 


### PR DESCRIPTION
Recent changes to LLVM libc++ discovered missing #includes. This code is using strtol and getenv, so it needs to include `<cstdlib>` or `<stdlib.h>` - whichever is more consistent with the the project coding style.