### PR TITLE
Update the ISA after instruction decode

### DIFF
--- a/decoder/source/etmv4/trc_pkt_decode_etmv4i.cpp
+++ b/decoder/source/etmv4/trc_pkt_decode_etmv4i.cpp
@@ -1318,7 +1318,7 @@ void TrcPktDecodeEtmV4I::setElemTraceRangeInstr(OcsdTraceElement &elemIn, const 
     elemIn.setLastInstrCond(instr.is_conditional);
     elemIn.setAddrRange(addr_range.st_addr, addr_range.en_addr, addr_range.num_instr);
     if (executed)
-        instr.isa = instr.next_isa;
+        m_last_IS = instr.isa = instr.next_isa;
 }
 
 ocsd_err_t TrcPktDecodeEtmV4I::processAtom(const ocsd_atm_val atom)
@@ -1919,7 +1919,7 @@ ocsd_err_t TrcPktDecodeEtmV4I::processSourceAddress()
         m_return_stack.set_pop_pending();  // need to know next packet before we know what is to happen
         break;
     }
-    m_instr_info.isa = m_instr_info.next_isa;
+    m_last_IS = m_instr_info.isa = m_instr_info.next_isa;
 
     // set the trace range element.
     m_out_elem.addElem(pElem->getRootIndex());


### PR DESCRIPTION
For decoding ETM with thumb mode, we should also update the `m_last_IS` value from the instruction decoder.
Otherwise, the decoded ISA might be incorrect when handling the later context/atom element.
It might reflect an incorrect A32/T32 ISA.