### PR TITLE
Remove return stack check in exception pkt handler

### DIFF
--- a/decoder/source/etmv4/trc_pkt_decode_etmv4i.cpp
+++ b/decoder/source/etmv4/trc_pkt_decode_etmv4i.cpp
@@ -844,10 +844,6 @@ ocsd_err_t TrcPktDecodeEtmV4I::commitElements()
                 break;
 
             case P0_EXCEP:
-                // check if prev atom left us an indirect address target on the return stack
-                if ((err = returnStackPop()) != OCSD_OK)
-                    break;
-
                 nextRangeCheckClear();
                 err = processException();  // output trace + exception elements.
                 m_elem_res.P0_commit--;


### PR DESCRIPTION
The `EXCEPTION` element already contains the return address whenever receiving the exception return element according to the ETM spec.
Therefore, we don't actually need to pop the `return stack`. Otherwise, it will affect the return address for later `ATOM` elements.