### PR TITLE
Avoid flushing the return stack for trace info

### DIFF
--- a/decoder/source/etmv4/trc_pkt_decode_etmv4i.cpp
+++ b/decoder/source/etmv4/trc_pkt_decode_etmv4i.cpp
@@ -103,7 +103,6 @@ ocsd_datapath_resp_t TrcPktDecodeEtmV4I::processPacket()
             {
                 doTraceInfoPacket();
                 m_curr_state = DECODE_PKTS;
-                m_return_stack.flush();
             }
             /* ETE spec allows early event packets. */
             else if ((m_config->MajVersion() >= 0x5) && 
@@ -326,11 +325,7 @@ ocsd_err_t TrcPktDecodeEtmV4I::decodePacket()
     {
     case ETM4_PKT_I_ASYNC: // nothing to do with this packet.
     case ETM4_PKT_I_IGNORE: // or this one.
-        break;
-
     case ETM4_PKT_I_TRACE_INFO:
-        // skip subsequent TInfo packets.
-        m_return_stack.flush();
         break;
 
     case ETM4_PKT_I_TRACE_ON:


### PR DESCRIPTION
Flushing the return stack upon receiving a trace info packet risks underflow if the processing needs to pop the return stack in the subsequent packets .

According to the ETM spec, it also suggests we don't need to flush the stack maintained by ourself as there are no adverse consequences if the contents of the trace analyzer return stack are retained.